### PR TITLE
Add Data for ScalarConf

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The conference dataset hosted in this repository tracks the following informatio
 | [Functional Scala](https://functionalscala.com) | Ziverge | Yes | Yes | Partial | Never |
 | [LambdaConf](https://lambdaconf.us) | Ziverge | Yes | Yes | Partial | Never |
 | [ZIO World](https://zioworld.com) | Ziverge | Yes | Yes | No | Never |
+| [ScalarConf](https://www.scalar-conf.com) | Software Mill | No | Yes | No | Never | 
 
 ## Contributing
 


### PR DESCRIPTION
This Pull Request adds data for Scalar Conf to the Conference Dataset on the Readme File. The data has been taken from various pages on their official website: https://www.scalar-conf.com/. Closes Issue #3 

/claim #3