### PR TITLE
Added JSConf data to the data tracker #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The conference dataset hosted in this repository tracks the following informatio
 | [ZIO World](https://zioworld.com) | Ziverge | Yes | Yes | No | Never |
 | [ScalarConf](https://www.scalar-conf.com) | Software Mill | No | Yes | No | Never | 
 | [PyCon](https://pycon.org) | PyCon Board Committee | Pending | No | Yes | Keynote |
-| [JSConf](https://jsconf.com/) | Local Community | No | Yes | Partial | Yes | 
+| [JSConf](https://jsconf.com/) | Local Community | Varies | Yes | Partial | Yes | 
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The conference dataset hosted in this repository tracks the following informatio
 | [ZIO World](https://zioworld.com) | Ziverge | Yes | Yes | No | Never |
 | [ScalarConf](https://www.scalar-conf.com) | Software Mill | No | Yes | No | Never | 
 | [PyCon](https://pycon.org) | PyCon Board Committee | Pending | No | Yes | Keynote |
+| [JSConf](https://jsconf.com/) | Local Community | No | Yes | Partial | Yes | 
+
 
 ## Contributing
 


### PR DESCRIPTION
This data is collected from the available organizational site https://jsconf.com/ and other resources online can change over time. /claim #8

Conference: JSConf 

Organizer: Local community or organization.  Each JSConf event is typically organized by a local team or community of JavaScript enthusiasts.

SEA: Since the organization or community is not fixed it's not feasible. Also, the agreements may vary depending on the specific event and its organizers.

Free Ticket: JSConf events do provide free or discounted tickets to speakers as a form of compensation or scholarship for their participation.

Reimburse Expenses: Partial, As the typical expenses that may be reimbursed can include travel costs, accommodation, meals, and other reasonable expenses.

Compensate Speakers: Often yes, But depends on the organizing community or organizations and the sponsors.