### PR TITLE
Update NESCALA Conf data

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The conference dataset hosted in this repository tracks the following informatio
 | [ScalarConf](https://www.scalar-conf.com) | [Software Mill](https://softwaremill.com/) | No | Yes | No | Never | 
 | [PyCon](https://pycon.org) | PyCon Board Committee | Pending | No | Yes | Keynote |
 | [JSConf](https://jsconf.com/) | Local Community | Varies | Yes | Partial | Yes | 
+| [NESCALA](https://github.com/nescalas/nescalas.github.io) | Volunteers | No | Partial | No | Never | 
+
 
 
 ## Contributing


### PR DESCRIPTION
Closes #6 
This data has been taken from the [ collection ](https://github.com/nescalas/nescalas.github.io) of all the conferences conducted in the past and also after contacting the organizer. 

Signing SEA - The organizers showed their unwillingness to participate in this.

Free Tickets - Often the Speakers were offered an off on the actual ticket price however the tickets are very affordable.

Reimbursement - There is no mention of reimbursements so considering it as no.

Compensation - Same as that of the Reimbursement.

/claim #6