### PR TITLE
Adds Øredev to the conference data tracker #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The conference dataset hosted in this repository tracks the following informatio
 | [PyCon](https://pycon.org) | PyCon Board Committee | Pending | No | Yes | Keynote |
 | [JSConf](https://jsconf.com/) | Local Community | Varies | Yes | Partial | Yes | 
 | [NESCALA](https://github.com/nescalas/nescalas.github.io) | Volunteers | No | Partial | No | Never | 
-
+| [Øredev](https://oredev.org/) | [Öredev AB](https://oredev.org) | No | No | No | Never | 
 
 
 ## Contributing


### PR DESCRIPTION
Closes #13 

This data has been added after going through the official site of the conf experience blog posts of the conferences conducted in the past and also after contacting the organizer.

Signing SEA - In the first week of this month, I eagerly contacted the organizing team of the Conference, and to my surprise, I got a response in a quick span asking for further details and clarifications on the data that is going to be used however after clarifying and referencing the agreement, they did not respond even after two followups. So I'm considering it as a no.

Free Tickets -  No free tickets per se.

Reimbursement - There is no mention of reimbursements, so I am considering it as a no.

Compensation - Though there is no mention of compensation anywhere, often the Speakers were offered a grand welcome, luxury stay, and donations as gifts.  

/claim #13