### PR TITLE
Add QCon to the conference data tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ The conference dataset hosted in this repository tracks the following informatio
 |------------|-----------|-----------|--------------|---------------------|----------------------|  
 | [Code Europe](https://www.codeeurope.pl/en/) | [Absolvent](https://www.absolvent.pl/informacje/o-nas#/) | Yes | Yes | Yes | Never |
 | [Functional Scala](https://functionalscala.com) | [Ziverge](https://ziverge.com) | Yes | Yes | Partial | Never |
-| [LambdaConf](https://lambdaconf.us) | [Ziverge](https://ziverge.com) | Yes | Yes | Partial | Workshops |
-| [ZIO World](https://zioworld.com) | [Ziverge](https://ziverge.com) | Yes | Yes | No | Never |
-| [ScalarConf](https://www.scalar-conf.com) | [Software Mill](https://softwaremill.com/) | No | Yes | No | Never | 
-| [PyCon](https://pycon.org) | PyCon Board Committee | Pending | No | Yes | Keynote |
 | [JSConf](https://jsconf.com/) | Local Community | Varies | Yes | Partial | Yes | 
+| [LambdaConf](https://lambdaconf.us) | [Ziverge](https://ziverge.com) | Yes | Yes | Partial | Workshops |
 | [NESCALA](https://github.com/nescalas/nescalas.github.io) | Volunteers | No | Partial | No | Never | 
+| [PyCon](https://pycon.org) | PyCon Board Committee | Pending | No | Yes | Keynote |
+| [QCon](https://qconferences.com/) | [C4Media](https://c4media.com/) | No | Yes | Yes | Never | 
+| [ScalarConf](https://www.scalar-conf.com) | [Software Mill](https://softwaremill.com/) | No | Yes | No | Never | 
+| [ZIO World](https://zioworld.com) | [Ziverge](https://ziverge.com) | Yes | Yes | No | Never |
 
 
 


### PR DESCRIPTION
I have contacted Qcon, and their reply regarding SEA was "speakers will sign our provided speaking forms along with agreeing to the event terms and conditions", They will provide a free ticket to the speaker along with a flat stipend to assist with travel along with making hotel reservations for a specified number of days. Both depend on where the speaker is based. No compensation of any sort was mentioned whatsoever.
/close #11  
/claim #11 
