### PR TITLE
Add CodeMash, QCon, and Scala Days conference entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,19 @@ The conference dataset hosted in this repository tracks the following informatio
 | Conference | Organizer | Sign SEA? | Free Ticket? | Reimburse Expenses? | Compensate Speakers? |  
 |------------|-----------|-----------|--------------|---------------------|----------------------|  
 | [Code Europe](https://www.codeeurope.pl/en/) | [Absolvent](https://www.absolvent.pl/informacje/o-nas#/) | Yes | Yes | Yes | Never |
+| [CodeMash](https://codemash.org/) | [CodeMash Organizers](https://codemash.org/organizers/) | No | Yes | Partial | Workshops |
 | [Functional Scala](https://functionalscala.com) | [Ziverge](https://ziverge.com) | Yes | Yes | Partial | Never |
+| [GOTO](https://gotopia.tech/) | [Trifork](https://trifork.com/) | Yes | No | Reasonable | Never |
+| [JSConf](https://jsconf.com/) | Local Community | Varies | Yes | Partial | Yes |
 | [LambdaConf](https://lambdaconf.us) | [Ziverge](https://ziverge.com) | Yes | Yes | Partial | Workshops |
-| [ZIO World](https://zioworld.com) | [Ziverge](https://ziverge.com) | Yes | Yes | No | Never |
-| [ScalarConf](https://www.scalar-conf.com) | [Software Mill](https://softwaremill.com/) | No | Yes | No | Never | 
-| [PyCon](https://pycon.org) | PyCon Board Committee | Pending | No | Yes | Keynote |
-| [JSConf](https://jsconf.com/) | Local Community | Varies | Yes | Partial | Yes | 
+| [Lambda World](https://www.lambda.world/) | [Xebia Functional](https://www.47deg.com/) | Yes | No | Yes | Never |
 | [NESCALA](https://github.com/nescalas/nescalas.github.io) | Volunteers | No | Partial | No | Never | 
-| [Øredev](https://oredev.org/) | [Öredev AB](https://oredev.org) | No | No | No | Never | 
-| [Lambda World](https://www.lambda.world/) | [Xebia Functional](https://www.47deg.com/) | Yes | No | Yes | Never | 
-| [GOTO](https://gotopia.tech/) | [Trifork](https://trifork.com/) | Yes | No | Reasonable  | Never | 
+| [Øredev](https://oredev.org/) | [Öredev AB](https://oredev.org) | No | No | No | Never |
+| [PyCon](https://pycon.org) | PyCon Board Committee | Pending | No | Yes | Keynote |
+| [QCon](https://qconferences.com/) | [C4Media](https://c4media.com/) | No | Yes | Partial | Never |
+| [Scala Days](https://scaladays.org/) | [Scala Center](https://scala.epfl.ch/) | No | Yes | Partial | Never |
+| [ScalarConf](https://www.scalar-conf.com) | [Software Mill](https://softwaremill.com/) | No | Yes | No | Never |
+| [ZIO World](https://zioworld.com) | [Ziverge](https://ziverge.com) | Yes | Yes | No | Never |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The conference dataset hosted in this repository tracks the following informatio
 | [Øredev](https://oredev.org/) | [Öredev AB](https://oredev.org) | No | No | No | Never |
 | [PyCon](https://pycon.org) | PyCon Board Committee | Pending | No | Yes | Keynote |
 | [QCon](https://qconferences.com/) | [C4Media](https://c4media.com/) | No | Yes | Partial | Never |
-| [Scala Days](https://scaladays.org/) | [Scala Center](https://scala.epfl.ch/) | No | Yes | Partial | Never |
+| [Scala Days](https://scaladays.org/) | [Scala Center](https://scala.epfl.ch/), [Xebia Functional](https://xebia.com/) | No | Yes | Yes | Never |
 | [ScalarConf](https://www.scalar-conf.com) | [Software Mill](https://softwaremill.com/) | No | Yes | No | Never |
 | [ZIO World](https://zioworld.com) | [Ziverge](https://ziverge.com) | Yes | Yes | No | Never |
 


### PR DESCRIPTION
## Summary
- add `CodeMash`, `QCon`, and `Scala Days` rows to the dataset table
- normalize table ordering by conference name for easier maintenance
- keep existing schema/columns unchanged

## Source notes
- CodeMash speaker benefits: https://codemash.org/call-for-speakers-announcement/ (speaker pass + housing credit + workshop honorarium for precompiler sessions)
- QCon organizer identity: https://c4media.com/ and conference home https://qconferences.com/
- Scala Days speaker support references: https://www.scala-lang.org/blog/2019/01/17/scala-days-2019-celebrating-collaborative-success.html

/claim #4
/claim #10
/claim #11