### PR TITLE
Add CodeMash conference data

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The conference dataset hosted in this repository tracks the following informatio
 | Conference | Organizer | Sign SEA? | Free Ticket? | Reimburse Expenses? | Compensate Speakers? |  
 |------------|-----------|-----------|--------------|---------------------|----------------------|  
 | [Code Europe](https://www.codeeurope.pl/en/) | [Absolvent](https://www.absolvent.pl/informacje/o-nas#/) | Yes | Yes | Yes | Never |
+| [CodeMash](https://codemash.org/) | [CodeMash Conference](https://codemash.org/faq/) | No | Yes | Partial | Workshops |
 | [Functional Scala](https://functionalscala.com) | [Ziverge](https://ziverge.com) | Yes | Yes | Partial | Never |
 | [LambdaConf](https://lambdaconf.us) | [Ziverge](https://ziverge.com) | Yes | Yes | Partial | Workshops |
 | [ZIO World](https://zioworld.com) | [Ziverge](https://ziverge.com) | Yes | Yes | No | Never |


### PR DESCRIPTION
## Summary
- Add CodeMash to the conference dataset table.
- Preserve the existing README schema and place the row after Code Europe.

## Source notes
- CodeMash FAQ identifies CodeMash Conference as an Ohio non-profit 501(c)(6) entity and says it is organized by volunteers from the professional developer community: https://codemash.org/faq/
- CodeMash organizer page lists the current volunteer organizer team: https://codemash.org/organizers/
- CodeMash speaker benefits page lists a four-day pass, hotel room / housing credit, speaker-room access, and a $250 honorarium for PreCompiler workshops only: https://codemash.org/call-for-speakers-announcement/

## Data choices
- Sign SEA: `No`, conservatively, because I did not find public confirmation that CodeMash will sign the Speaker Engagement Agreement.
- Free Ticket: `Yes`, because credentialed speakers receive a four-day pass.
- Reimburse Expenses: `Partial`, because public speaker benefits describe hotel/housing support rather than full travel reimbursement.
- Compensate Speakers: `Workshops`, because the public policy lists an honorarium for PreCompiler workshops only.

## Verification
- Reviewed the updated README table from the pushed branch and confirmed the CodeMash row has the same six data columns as the existing rows.
- Not run locally: this Codex environment could not create a normal local working tree earlier, so this docs/data-only patch was prepared through the GitHub connector.

/claim #10

Closes #10