### PR TITLE
Add QCon conference data

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The conference dataset hosted in this repository tracks the following informatio
 | [ZIO World](https://zioworld.com) | [Ziverge](https://ziverge.com) | Yes | Yes | No | Never |
 | [ScalarConf](https://www.scalar-conf.com) | [Software Mill](https://softwaremill.com/) | No | Yes | No | Never | 
 | [PyCon](https://pycon.org) | PyCon Board Committee | Pending | No | Yes | Keynote |
+| [QCon](https://qconferences.com/) | [C4Media](https://c4media.com/) | No | Yes | Full | Never |
 | [JSConf](https://jsconf.com/) | Local Community | Varies | Yes | Partial | Yes | 
 | [NESCALA](https://github.com/nescalas/nescalas.github.io) | Volunteers | No | Partial | No | Never | 
 | [Øredev](https://oredev.org/) | [Öredev AB](https://oredev.org) | No | No | No | Never | 


### PR DESCRIPTION
## Summary
- Add QCon to the conference dataset table.
- List C4Media as the organizer and preserve the existing README schema.

## Source notes
- QConferences presents QCon as a software development conference series for senior software engineers, architects, and technical leaders: https://qconferences.com/
- C4Media describes its in-person events as including QCon London, QCon AI Boston, QCon San Francisco, and QCon AI NYC: https://c4media.com/advertiser-sponsor-resources
- QCon SF speaker-support material says QCon offers budget for travel and accommodation arrangements for all speakers: https://qconsf.com/qcon-cares#speaker-support

## Data choices
- Sign SEA: `No`, conservatively, because I did not find a public commitment to sign the Speaker Engagement Agreement.
- Free Ticket: `Yes`, because invited speakers need conference access and QCon speaker-support material discusses speaker participation in the event.
- Reimburse Expenses: `Full`, because the public speaker-support material says QCon offers budget for travel and accommodation arrangements for all speakers.
- Compensate Speakers: `Never`, because I did not find a direct speaker-fee or honorarium commitment.

## Verification
- Reviewed the pushed README branch and confirmed the QCon row has the same six data columns as the existing rows.
- Not run locally: this docs/data-only patch was prepared through the GitHub connector because local git/file writes were unreliable in this Codex environment earlier.

/claim #11

Closes #11