### PR TITLE
Add Scala Days conference data

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The conference dataset hosted in this repository tracks the following informatio
 | [LambdaConf](https://lambdaconf.us) | [Ziverge](https://ziverge.com) | Yes | Yes | Partial | Workshops |
 | [ZIO World](https://zioworld.com) | [Ziverge](https://ziverge.com) | Yes | Yes | No | Never |
 | [ScalarConf](https://www.scalar-conf.com) | [Software Mill](https://softwaremill.com/) | No | Yes | No | Never | 
+| [Scala Days](https://scaladays.org/) | [Scala Center](https://scala.epfl.ch/) / [Plain Schwarz](https://plainschwarz.com/) | No | Yes | No | Never |
 | [PyCon](https://pycon.org) | PyCon Board Committee | Pending | No | Yes | Keynote |
 | [JSConf](https://jsconf.com/) | Local Community | Varies | Yes | Partial | Yes | 
 | [NESCALA](https://github.com/nescalas/nescalas.github.io) | Volunteers | No | Partial | No | Never | 


### PR DESCRIPTION
## Summary
- Add Scala Days to the conference dataset table.
- List Scala Center and Plain Schwarz as the current 2026 organizing partnership.

## Source notes
- Official Scala Days site lists Scala Days 2026 in Berlin on October 12-13, 2026: https://scaladays.org/
- The Scala language announcement says Scala Center partnered with Plain Schwarz for Scala Days 2026: https://www.scala-lang.org/blog/2026/03/26/scala-days-2026.html
- The current CFP describes the accepted session formats as talks, interactive labs, and workshops: https://www.scala-lang.org/blog/2026/04/30/scala-days-2026-cfp.html

## Data choices
- Sign SEA: `No`, conservatively, because I did not find a public commitment to sign the Speaker Engagement Agreement.
- Free Ticket: `Yes`, because selected speakers need event access to present at the conference.
- Reimburse Expenses: `No`, because I did not find a public travel or accommodation reimbursement commitment.
- Compensate Speakers: `Never`, because I did not find a public speaker-fee or honorarium commitment.

## Verification
- Reviewed the pushed README branch and confirmed the Scala Days row uses the same six data columns as the existing rows.
- Not run locally: this is a docs/data-only README change prepared through the GitHub connector.

/claim #4

Closes #4