### PR TITLE
Add CodeMash conference data

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The conference dataset hosted in this repository tracks the following informatio
 | Conference | Organizer | Sign SEA? | Free Ticket? | Reimburse Expenses? | Compensate Speakers? |  
 |------------|-----------|-----------|--------------|---------------------|----------------------|  
 | [Code Europe](https://www.codeeurope.pl/en/) | [Absolvent](https://www.absolvent.pl/informacje/o-nas#/) | Yes | Yes | Yes | Never |
+| [CodeMash](https://codemash.org/) | [CodeMash Conference](https://codemash.org/faq/) | No | Yes | Partial | Never |
 | [Functional Scala](https://functionalscala.com) | [Ziverge](https://ziverge.com) | Yes | Yes | Partial | Never |
 | [LambdaConf](https://lambdaconf.us) | [Ziverge](https://ziverge.com) | Yes | Yes | Partial | Workshops |
 | [ZIO World](https://zioworld.com) | [Ziverge](https://ziverge.com) | Yes | Yes | No | Never |
@@ -56,3 +57,4 @@ If you want to amend or add information to the table, please follow these steps:
 7. Save your changes and submit a pull request with a brief explanation of the changes you made.  
 8. If you are not the organizer, please explain how you acquired the information you are adding to the table.
 9. Once your pull request is reviewed and merged, the changes will be updated to the main branch of the repository.  
+


### PR DESCRIPTION
## Summary
- Adds CodeMash to the conference data tracker.
- Uses current public CodeMash 2026 / Sessionize sources.
- Keeps conservative values where no public SEA or general speaker-fee commitment is available.

## Sources / notes
- CodeMash FAQ: CodeMash Conference is incorporated as an Ohio non-profit / 501(c)(6), and organized by volunteers.
- CodeMash organizers page: current board and volunteer organizer context.
- Sessionize CodeMash 2026: event fee is free for speakers, accommodation expenses are covered, up to four hotel nights are covered, and limited travel assistance is available on a needs basis.
- I did not find a public commitment to sign the Speaker Engagement Agreement or a current general speaker-fee policy, so those fields are conservative per the issue guidance.

## Validation
- Preserved the existing Markdown table schema and alphabetical placement.
- Local table check: each table row keeps 7 pipe characters / 6 data columns.

/claim #10

AI-assisted; reviewed before submission.