### PR TITLE
Add CodeMash conference data

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The conference dataset hosted in this repository tracks the following informatio
 | Conference | Organizer | Sign SEA? | Free Ticket? | Reimburse Expenses? | Compensate Speakers? |  
 |------------|-----------|-----------|--------------|---------------------|----------------------|  
 | [Code Europe](https://www.codeeurope.pl/en/) | [Absolvent](https://www.absolvent.pl/informacje/o-nas#/) | Yes | Yes | Yes | Never |
+| [CodeMash](https://codemash.org/) | [CodeMash Conference Corporation](https://codemash.org/faq/) | No | Yes | Partial | PreCompilers |
 | [Functional Scala](https://functionalscala.com) | [Ziverge](https://ziverge.com) | Yes | Yes | Partial | Never |
 | [LambdaConf](https://lambdaconf.us) | [Ziverge](https://ziverge.com) | Yes | Yes | Partial | Workshops |
 | [ZIO World](https://zioworld.com) | [Ziverge](https://ziverge.com) | Yes | Yes | No | Never |


### PR DESCRIPTION
## Summary

/claim #10

Adds CodeMash to the conference data tracker using public CodeMash sources while preserving the existing README table schema and alphabetical placement.

## Source notes

- Conference homepage: https://codemash.org/
- Organizer/legal entity: https://codemash.org/faq/
- Speaker benefits: https://codemash.org/call-for-speakers-announcement/

## Field notes

- `Sign SEA?`: `No` because I did not find a public statement that CodeMash signs the Speaker Engagement Agreement.
- `Free Ticket?`: `Yes` based on the published speaker benefits listing a four-day CodeMash pass.
- `Reimburse Expenses?`: `Partial` because the published speaker benefits list hotel room / housing-credit support, but not full travel and per diem reimbursement.
- `Compensate Speakers?`: `PreCompilers` because the speaker-benefits source describes a PreCompiler workshop honorarium.

## Validation

- Markdown table pipe-count check: all rows have the expected column count.
- `git diff --check -- README.md`
- Source-link HTTP checks returned `200` for the CodeMash homepage, FAQ, and speaker-benefits page.

## Demo note

This is a static README data update, so the PR diff is the review/demo surface.