### PR TITLE
Add CodeMash conference data

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The conference dataset hosted in this repository tracks the following informatio
   
 | Conference | Organizer | Sign SEA? | Free Ticket? | Reimburse Expenses? | Compensate Speakers? |  
 |------------|-----------|-----------|--------------|---------------------|----------------------|  
+| [CodeMash](https://codemash.org/) | [CodeMash Conference](https://codemash.org/About/) | No | Yes | Partial | Workshops |
 | [Code Europe](https://www.codeeurope.pl/en/) | [Absolvent](https://www.absolvent.pl/informacje/o-nas#/) | Yes | Yes | Yes | Never |
 | [Functional Scala](https://functionalscala.com) | [Ziverge](https://ziverge.com) | Yes | Yes | Partial | Never |
 | [LambdaConf](https://lambdaconf.us) | [Ziverge](https://ziverge.com) | Yes | Yes | Partial | Workshops |


### PR DESCRIPTION
/claim #10

Adds CodeMash to the conference dataset using public CodeMash sources and the issue's conservative SEA guidance.

Sources:
- CodeMash speaker benefits / CFP details: https://codemash.org/call-for-speakers-announcement/
- CodeMash 2026 CFP announcement: https://codemash.org/codemash-2026-call-for-speakers/
- CodeMash overview / organizer page: https://codemash.org/About/

Values added:
- Sign SEA?: `No`, because the issue says to assume no SEA willingness unless the organizer confirms otherwise.
- Free Ticket?: `Yes`, because speaker benefits include a four day pass.
- Reimburse Expenses?: `Partial`, because speaker benefits include a housing credit rather than full travel reimbursement.
- Compensate Speakers?: `Workshops`, because PreCompiler workshop sessions receive an honorarium.

Validation:
- Checked the README table rows keep the expected column count.
